### PR TITLE
Update ManagerStations_Research.xml

### DIFF
--- a/Defs/ResearchProjectDefs/ManagerStations_Research.xml
+++ b/Defs/ResearchProjectDefs/ManagerStations_Research.xml
@@ -10,6 +10,8 @@ Develop basic software for colony management.
 Allows building manager desks with a computer, pre-installed with a host of guaranteed bug free(tm) managing software.
         </description>
         <totalCost>1500</totalCost>
+        <techLevel>Industrial</techLevel>
+        <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
         <prerequisites></prerequisites>
     </ResearchProjectDef>
 
@@ -22,6 +24,8 @@ Develop advanced software for colony management.
 Advancements in AI and colony-aware computers allow the building of Colony Aware Supercomputers, preinstalled with FluffyOS. Some colonists have reported doors opening and closing, airconditioning systems going haywire, and electric smelters suddenly turning on. Nevertheless, the manufacturer guarantees(tm) that FluffyOS is not programmed to kill colonists. 
         </description>
         <totalCost>2500</totalCost>
+        <techLevel>Spacer</techLevel>
+        <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
         <prerequisites>
             <li>ManagingSoftware</li>
         </prerequisites>
@@ -33,6 +37,8 @@ Advancements in AI and colony-aware computers allow the building of Colony Aware
         <description>Create management software to monitor the colony's power usage. 
         </description>
         <totalCost>1000</totalCost>
+        <techLevel>Industrial</techLevel>
+        <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
         <prerequisites>
             <li>ManagingSoftware</li>
         </prerequisites>


### PR DESCRIPTION
- Adds tech levels (currently undefined)
- Adds "Hi Tech Research Bench" as required research building (basically gating the researches behind MicroElectronics Basics, which seems logical as the description of the first research mentions computers)